### PR TITLE
Changes the display of percentages

### DIFF
--- a/main.py
+++ b/main.py
@@ -97,7 +97,8 @@ def dostats(lootboxopener):
     for item, itemcount in items.items():
         print(f"Opened {itemcount} of {itemmap[item]}")
     for item, itemcount in items.items():
-        print(f"Item {itemmap[item]} has a chance of {(itemcount/count)*100}%")
+        item_percent = (itemcount/count)*100
+        print(f"Item {itemmap[item]} has a chance of {item_percent:.2f}%")
 
 
 def main():


### PR DESCRIPTION
Before the change, the output looked like this:

```
Item Quack!! has a chance of 10.714285714285714%
Item ⮕⬆⬇⮕⬆⬇ has a chance of 10.714285714285714%
Item Wump Shell has a chance of 7.142857142857142%
...
```

Now it will only show the two first digits after the period (5.55%), making it look cleaner and more readable.